### PR TITLE
扫荡信息只在扫荡时显示

### DIFF
--- a/src/views/endlessPage.vue
+++ b/src/views/endlessPage.vue
@@ -14,7 +14,7 @@
         <div class="actions">
             <el-button v-for="(item, index) in buttonData" :key="index" @click="item.click" :disabled="item.disabled" v-text="item.text" />
         </div>
-        <div class="sweep-info">
+        <div v-if="isSweepingData" class="sweep-info">
             <el-row>
                 <el-col :span="6" v-for="(item, index) in sweepData" :key="index">
                     <div class="el-statistic">
@@ -132,6 +132,10 @@
             tag
         },
         computed: {
+            // 是否在扫荡
+            isSweepingData () {
+                return this.isSweeping;
+            },
             // 扫荡相关信息
             sweepData () {
                 return [


### PR DESCRIPTION
## Summary by Sourcery

增强无尽页面视图，仅在清扫进行时有条件地显示清扫信息。

增强功能：
- 通过添加条件检查，仅在清扫活动时显示清扫信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the endless page view to conditionally display sweep information only when sweeping is in progress.

Enhancements:
- Display sweep information only when sweeping is active by adding a conditional check.

</details>