### PR TITLE
fix: 修复神兵无法炼器的bug

### DIFF
--- a/src/views/homePage.vue
+++ b/src/views/homePage.vue
@@ -86,7 +86,7 @@
                       <template #reference>
                        <tag v-if="player.equipment.weapon?.name" :type="player.equipment.weapon?.quality"
                             :closable="player.equipment.weapon?.name ? true : false" @close="equipmentClose('weapon')"
-                            @click="equipmentInfo(player.equipment[type].id,'weapon')" @mouseenter="getEquipmentInfo(player.equipment['weapon']?.id,'weapon')">
+                            @click="equipmentInfo(player.equipment['weapon']?.id,'weapon')" @mouseenter="getEquipmentInfo(player.equipment['weapon']?.id,'weapon')">
                                               {{
                            player.equipment.weapon?.name
                          }}{{ player.equipment.weapon?.strengthen ? '+' + player.equipment.weapon?.strengthen : '' }}


### PR DESCRIPTION
## 由 Sourcery 总结

错误修复：
- 修正了装备信息的方法调用，现已使用正确的属性访问方式获取武器装备

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the method call for equipment info to use the correct property access for weapon equipment

</details>