### PR TITLE
fix: 修复查看背包装备会导致装备强化等级重置的bug。

### DIFF
--- a/src/views/homePage.vue
+++ b/src/views/homePage.vue
@@ -1832,8 +1832,9 @@ export default {
             // 需要炼器的装备信息
             this.strengthenInfo = equipment;
             // 炼器等级
-            if (this.player.equipment[type]) {
-              this.player.equipment[type].strengthen = equipment.strengthen ? equipment.strengthen : 0;
+            // Only update strengthen info if it doesn't exist in the equipped item
+            if (this.player.equipment[type] && !this.player.equipment[type].hasOwnProperty('strengthen')) {
+                this.player.equipment[type].strengthen = equipment.strengthen || 0;
             }
           },
             // 装备信息


### PR DESCRIPTION
修复查看背包装备会导致装备强化等级重置的bug。而装备属性却仍然存在，导致装备可以反复强化，增加属性

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了查看背包中的装备可能重置其强化等级的问题，允许重复强化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix an issue where viewing equipment in the inventory could reset its strengthen level, allowing repeated strengthening.

</details>