### PR TITLE
fix: 修复查看背包装备会导致装备强化等级重置的bug。

### DIFF
--- a/src/views/homePage.vue
+++ b/src/views/homePage.vue
@@ -2350,7 +2350,7 @@
     // 需要炼器的装备信息
     strengthenInfo.value = equipment
     // 炼器等级
-    if (player.value.equipment[type] && !player.equipment[type].hasOwnProperty('strengthen')) {
+    if (player.value.equipment[type] && !player.value.equipment[type].hasOwnProperty('strengthen')) {
       player.value.equipment[type].strengthen = equipment?.strengthen ? equipment?.strengthen : 0
     }
   }


### PR DESCRIPTION
修复查看背包装备会导致装备强化等级重置的bug。而装备属性却仍然存在，导致装备可以反复强化，增加属性

## Summary by Sourcery

Bug Fixes:
- 修复了打开背包装备详情时装备强化等级被重置的问题，该问题会导致可以重复强化以获得额外属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix equipment strengthen level being reset when opening backpack equipment details, which allowed repeated strengthening for extra attributes.

</details>